### PR TITLE
fix(web): handle missing `revset.log` in config file

### DIFF
--- a/lib/jjx_web/live/home_live.ex
+++ b/lib/jjx_web/live/home_live.ex
@@ -138,10 +138,9 @@ defmodule JjxWeb.HomeLive do
       configs = Native.get_configs(path)
 
       revset =
-        Enum.find_value(configs, fn {name, value} ->
-          if name == "revsets.log" do
-            String.trim(value, "\"")
-          end
+        Enum.find_value(configs, "ancestors(@, 10)", fn
+          {"revsets.log", value} -> String.trim(value, "\"")
+          _ -> nil
         end)
 
       {:ok, log} = Native.log(workspace, revset)


### PR DESCRIPTION
## Description

When `revset.log` is missing from user's config file, the web app fails to load valid `jj` repositories. To fix this, we fallback to a default revset expression when we're unable to find `revset.log` in the user's config.

However, it is worthy to note the default log revset introduced in this PR differs from `jj-lib`'s [default fallback](https://github.com/jj-vcs/jj/blob/59de83a84afb01462d383ed142b0ed726cf3b862/docs/config.md?plain=1#L499-L500). The revset expression we are using shows the latest 10 commits relative to the current working copy (`ancestors(@, 10)`).